### PR TITLE
Add get_mut methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,19 @@ impl<T> Vec<T> {
         self.raw.get(index)
     }
 
+    /// Returns a mutable reference to the element at the given index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut vec = boxcar::vec![10, 40, 30];
+    /// assert_eq!(Some(&mut 40), vec.get_mut(1));
+    /// assert_eq!(None, vec.get_mut(3));
+    /// ```
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        self.raw.get_mut(index)
+    }
+
     /// Returns a reference to an element, without doing bounds
     /// checking or verifying that the element is fully initialized.
     ///
@@ -202,6 +215,30 @@ impl<T> Vec<T> {
     pub unsafe fn get_unchecked(&self, index: usize) -> &T {
         // SAFETY: guaranteed by caller
         unsafe { self.raw.get_unchecked(index) }
+    }
+
+    /// Returns a mutable reference to an element, without doing bounds
+    /// checking or verifying that the element is fully initialized.
+    ///
+    /// For a safe alternative see [`get`](Vec::get).
+    ///
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index is **undefined
+    /// behavior**, even if the resulting reference is not used.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut vec = boxcar::vec![1, 2, 4];
+    ///
+    /// unsafe {
+    ///     assert_eq!(vec.get_unchecked_mut(1), &mut 2);
+    /// }
+    /// ```
+    pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
+        // SAFETY: guaranteed by caller
+        unsafe { self.raw.get_unchecked_mut(index) }
     }
 
     /// Returns an iterator over the slice.

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -199,6 +199,57 @@ impl<T> Vec<T> {
         }
     }
 
+    // Returns a mutable reference to the element at the given index.
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        let location = Location::of(index);
+
+        // SAFETY: we have enough buckets for `usize::MAX` entries
+        let entries = unsafe {
+            self.buckets
+                .get_unchecked_mut(location.bucket)
+                .entries
+                .get_mut()
+        };
+
+        // bucket is uninitialized
+        if entries.is_null() {
+            return None;
+        }
+
+        // SAFETY: `location.entry` is always in bounds for `location.bucket`
+        let entry = unsafe { &mut *entries.add(location.entry) };
+
+        if *entry.active.get_mut() {
+            // SAFETY: the entry is active
+            unsafe { return Some(entry.value_unchecked_mut()) }
+        }
+
+        // entry is uninitialized
+        None
+    }
+
+    // Returns a mutable reference to the element at the given index.
+    //
+    // # Safety
+    //
+    // Entry at `index` must be initialized.
+    pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
+        let location = Location::of(index);
+
+        // SAFETY: caller guarantees index is in bounds and
+        // entry is present.
+        unsafe {
+            let entry = self
+                .buckets
+                .get_unchecked_mut(location.bucket)
+                .entries
+                .get_mut()
+                .add(location.entry);
+
+            (*entry).value_unchecked_mut()
+        }
+    }
+
     // Returns an iterator over the vector.
     pub fn iter(&self) -> Iter {
         Iter {
@@ -359,6 +410,14 @@ impl<T> Entry<T> {
     unsafe fn value_unchecked(&self) -> &T {
         // SAFETY: guaranteed by caller
         unsafe { (*self.slot.get()).assume_init_ref() }
+    }
+
+    // # Safety
+    //
+    // Value must be initialized.
+    unsafe fn value_unchecked_mut(&mut self) -> &mut T {
+        // SAFETY: guaranteed by caller
+        unsafe { self.slot.get_mut().assume_init_mut() }
     }
 }
 


### PR DESCRIPTION
It's convenient to be able to get `&mut` access to values when a `&mut boxvar::Vec` is available.