### PR TITLE
Performance Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 A concurrent, append-only vector.
 
-The vector provided by this crate suports concurrent `get` and `push` operations.
-Reads are always lock-free, as are writes except when resizing is required.
+The vector provided by this crate suports concurrent `get` and `push` operations. All operations are lock-free.
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,3 @@ fn main() {
     assert_eq!(*x, 2);
 }
 ```
-
-# Performance
-
-Below is a benchmark in which an increasing number of elements are pushed and read from the vector
-by 12 threads, comparing `boxcar::Vec` to `RwLock<Vec>`:
-
-<img width="1024" alt="Benchmark" src="https://user-images.githubusercontent.com/34988408/158077862-a2a58be5-cbf0-4a2f-bbc2-202a026678c2.png">
-
-The results show that `boxcar::Vec` scales very well under load, performing significantly better
-than lock-based solutions.

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -1,0 +1,80 @@
+use std::{sync::Barrier, thread};
+
+#[test]
+fn simple() {
+    let vec = boxcar::vec![0, 1, 2];
+    for x in 3..1000 {
+        let i = vec.push(x);
+        assert_eq!(vec[i], x);
+    }
+
+    for i in 0..1000 {
+        assert_eq!(vec[i], i);
+    }
+
+    for (i, &x) in vec.iter() {
+        assert_eq!(i, x);
+    }
+
+    for (i, x) in vec.into_iter().enumerate() {
+        assert_eq!(i, x);
+    }
+}
+
+#[test]
+fn stress() {
+    let vec = boxcar::Vec::new();
+    let barrier = Barrier::new(6);
+
+    thread::scope(|s| {
+        s.spawn(|| {
+            barrier.wait();
+            for i in 0..1000 {
+                vec.push(i);
+            }
+        });
+
+        s.spawn(|| {
+            barrier.wait();
+            for i in 1000..2000 {
+                vec.push(i);
+            }
+        });
+
+        s.spawn(|| {
+            barrier.wait();
+            for i in 2000..3000 {
+                vec.push(i);
+            }
+        });
+
+        s.spawn(|| {
+            barrier.wait();
+            for i in 3000..4000 {
+                vec.push(i);
+            }
+        });
+
+        s.spawn(|| {
+            barrier.wait();
+            for i in 0..10_000 {
+                if let Some(&x) = vec.get(i) {
+                    assert!(x < 4000);
+                }
+            }
+        });
+
+        s.spawn(|| {
+            barrier.wait();
+            for (i, &x) in vec.iter() {
+                assert!(x < 4000);
+                assert!(vec[i] < 4000);
+            }
+        });
+    });
+
+    assert_eq!(vec.count(), 4000);
+    let mut sorted = vec.into_iter().collect::<Vec<_>>();
+    sorted.sort();
+    assert_eq!(sorted, (0..4000).collect::<Vec<_>>());
+}


### PR DESCRIPTION
- Vector is now lock-free, writers race to allocate
- Writers preallocate next bucket when previous is 7/8 full
- Buckets start at size 32
- The size of the `Vec` is significantly reduced

Closes https://github.com/ibraheemdev/boxcar/issues/1.