### PR TITLE
Add original license test to bench.rs, and omit it and other unnecessary files from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ repository = "https://github.com/ibraheemdev/boxcar"
 
 keywords = ["concurrent","vector","lock-free"]
 categories = ["concurrency", "data-structures"]
+exclude = [
+  ".gitignore",
+  ".github/**",
+  "benches/**",
+  "report.svg",
+]
 
 [[bench]]
 name = "bench"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,25 @@
 // adapted from: https://github.com/hawkw/sharded-slab/blob/main/benches/bench.rs
+// which carries the following MIT license:
+//
+// Copyright (c) 2019 Eliza Weisman
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use std::{
     sync::{Arc, Barrier, RwLock},


### PR DESCRIPTION
Since `bench.rs` is derived from the `bench.rs` in [`sharded-slab`](https://github.com/hawkw/sharded-slab), and the MIT license says “The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software,” we need to include the original license text.

Using a source comment to include the license text should be adequate, since it’s unlikely anyone would want to distribute the compiled benchmark executable.

----

As a follow-up, this PR excludes the benchmarks (along with a few other unnecessary files) from published crates. This makes the crate archives slightly smaller, and makes it very clear that nothing derived from `sharded-slab` is compiled into the crate library, which makes downstream license analysis easier.