### PR TITLE
Adds `push_with` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::needless_doctest_main)]
-#![no_std]
+// #![no_std]
 
 extern crate alloc;
 
@@ -140,6 +140,23 @@ impl<T> Vec<T> {
     /// ```
     pub fn push(&self, value: T) -> usize {
         self.raw.push(value)
+    }
+
+    /// Appends the element returned from the closure `f` to the back of the vector
+    /// at the index supplied to the closure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let vec = boxcar::vec![0, 1];
+    /// vec.push_with(|index| index + 1);
+    /// assert_eq!(vec, [0, 1, 2]);
+    /// ```
+    pub fn push_with<F>(&self, f: F) -> usize
+    where
+        F: Fn(usize) -> T,
+    {
+        self.raw.push_with(f)
     }
 
     /// Returns the number of elements in the vector.
@@ -451,3 +468,18 @@ where
 }
 
 impl<T: Eq> Eq for Vec<T> {}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn test_push_with() {
+        let v = super::vec![0, 1, 2];
+        println!("{v:?}");
+        v.push_with(|index| index + 1);
+        println!("{v:?}");
+        // v.push_with(|index| index + 1);
+        // v.push_with(|index| index + 1);
+        assert_eq!(v, [0, 1, 2, 3]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::needless_doctest_main)]
-// #![no_std]
+#![no_std]
 
 extern crate alloc;
 
@@ -468,18 +468,3 @@ where
 }
 
 impl<T: Eq> Eq for Vec<T> {}
-
-#[cfg(test)]
-mod test {
-
-    #[test]
-    fn test_push_with() {
-        let v = super::vec![0, 1, 2];
-        println!("{v:?}");
-        v.push_with(|index| index + 1);
-        println!("{v:?}");
-        // v.push_with(|index| index + 1);
-        // v.push_with(|index| index + 1);
-        assert_eq!(v, [0, 1, 2, 3]);
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let vec = boxcar::vec![0, 1];
-    /// vec.push_with(|index| index + 1);
+    /// vec.push_with(|index| index);
     /// assert_eq!(vec, [0, 1, 2]);
     /// ```
     pub fn push_with<F>(&self, f: F) -> usize

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ impl<T> Vec<T> {
     /// Appends the element returned from the closure `f` to the back of the vector
     /// at the index supplied to the closure.
     ///
+    /// Returns the index that the element was inserted into.
     /// # Examples
     ///
     /// ```

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -171,7 +171,7 @@ impl<T> Vec<T> {
         F: FnOnce(usize) -> T,
     {
         let index = self.next_index();
-        let value = f(index - 1);
+        let value = f(index);
         self.push_to(index, value)
     }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -171,7 +171,7 @@ impl<T> Vec<T> {
         F: FnOnce(usize) -> T,
     {
         let index = self.next_index();
-        let value = f(index);
+        let value = f(index - 1);
         self.push_to(index, value)
     }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -183,8 +183,7 @@ impl<T> Vec<T> {
     fn next_index(&self) -> usize {
         let index = self.inflight.fetch_add(1, Ordering::Relaxed);
         // the inflight counter is a `u64` to catch overflows of the vector'scapacity
-        let index: usize = index.try_into().expect("overflowed maximum capacity");
-        index
+        index.try_into().expect("overflowed maximum capacity")
     }
 
     fn push_to(&self, index: usize, value: T) -> usize {


### PR DESCRIPTION
Adds `push_with`, allowing for `T` to be produced by a closure which is passed the index of the element. 

Resolves #9.