### PR TITLE
Include benchmarks in publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["concurrency", "data-structures"]
 exclude = [
   ".gitignore",
   ".github/**",
-  "benches/**",
   "report.svg",
 ]
 


### PR DESCRIPTION
This partially reverts https://github.com/ibraheemdev/boxcar/pull/8. It is currently impossible to run `cargo publish` as the `Cargo.toml` manifest includes the benchmark target but excludes the file. Now that the full license file is included this shouldn't be a problem.