### PR TITLE
Switch AtomicU64 to portable-atomic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "bench"
 harness = false
 
 [dependencies]
-# ...
+portable-atomic = "1"
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -3,8 +3,9 @@
 use core::cell::UnsafeCell;
 use core::mem::{self, MaybeUninit};
 use core::ops::Index;
-use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize};
 use core::{ptr, slice};
+use portable_atomic::{AtomicU64, Ordering};
 
 use alloc::boxed::Box;
 


### PR DESCRIPTION
Adds a dependency on portable-atomic and uses it to import the AtomicU64 type. This allows building boxcar on 32-bit platforms like PowerPC and ARMv5TE.

Fixes #19.