### PR TITLE
Fix and fuse `vec::Iter`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod loom;
 mod raw;
 
 use core::fmt;
+use core::iter::FusedIterator;
 use core::ops::Index;
 
 /// Creates a [`Vec`] containing the given elements.
@@ -392,11 +393,16 @@ impl<T> Iterator for IntoIter<T> {
 
 /// An iterator over the elements of a [`Vec<T>`].
 ///
+/// Note that the iterator is [fused](FusedIterator) on creation, and
+/// will not continue to check for concurrently inserted elements.
+///
 /// See [`Vec::iter`] for details.
 pub struct Iter<'a, T> {
     vec: &'a raw::Vec<T>,
     raw: raw::Iter,
 }
+
+impl<T> FusedIterator for Iter<'_, T> {}
 
 impl<'a, T> Clone for Iter<'a, T> {
     fn clone(&self) -> Iter<'a, T> {

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -48,6 +48,24 @@ fn read_write() {
 }
 
 #[test]
+fn iter_linearizability() {
+    loom::model(|| {
+        let vec = Arc::new(boxcar::Vec::new());
+        let v1 = vec.clone();
+        let v2 = vec.clone();
+
+        let t1 = thread::spawn(move || v1.push(1));
+        let t2 = thread::spawn(move || {
+            v2.push(2);
+            assert!(v2.iter().find(|&(_, x)| *x == 2).is_some());
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    });
+}
+
+#[test]
 fn mixed() {
     loom::model(|| {
         let vec = Arc::new(boxcar::Vec::new());

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -87,6 +87,16 @@ fn clear() {
 }
 
 #[test]
+fn fused_iterator() {
+    let vec = boxcar::vec![0, 1, 2];
+    assert_eq!(vec.iter().collect::<Vec<_>>(), [(0, &0), (1, &1), (2, &2)]);
+
+    let iter = vec.iter();
+    vec.push(3);
+    assert_eq!(iter.collect::<Vec<_>>(), [(0, &0), (1, &1), (2, &2)]);
+}
+
+#[test]
 fn stress() {
     let vec = boxcar::Vec::new();
     let barrier = Barrier::new(6);


### PR DESCRIPTION
Currently `vec::Iter` stops if it yields `vec.count()` elements. This is incorrect in that it may *not* yield elements whose initialization was synchronized on the creation of the iterator, as we may read an out-of-date `vec.count()` while also have yielded an element that we didn't expect to (one that was concurrently initialized in-between elements that we meant to have yielded). This PR simplifies the iterator semantics and makes it completely fused on creation, whereas it previously may have continued to yield elements as they were added. I also simplified the implementation which may slightly hurt performance, but I think this will be fixed by https://github.com/ibraheemdev/boxcar/pull/31 anyways (which from a cursory look correctly handles these issues). This also fixes another bug where the index was not updated if we skip over an uninitialized bucket, though that would be *extremely* rare.

I think this was the underlying cause of https://github.com/astral-sh/ty/issues/115#issuecomment-2961376078, because Salsa relies on the iterator being linearizable, in particular, `vec.push(x); vec.iter().find(x).is_some();` should never fail.